### PR TITLE
Add Google Analytics template so users can add it

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,4 +33,8 @@
 
     <!-- RSS -->
     <link href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+
+    {{ if hugo.Environment | eq "production" }}
+        {{ template "_internal/google_analytics_async.html" . }}
+    {{ end }}
 </head>


### PR DESCRIPTION
Users may want to add Google Analytics tracking for their websites. Added Hugo's internal Google Analytics template (only if it's a production code). It won't add any tracking code if it's not on production.
To use this template you'll need to provide a tracking id in the `config.toml` file like this:
```toml
googleAnalytics = "UA-123-45"
```
Also if `googleAnalytics` value is not provided in the `config.toml`, it won't add anything to header. Users won't see any difference in their websites.

See: https://gohugo.io/templates/internal/#google-analytics