### PR TITLE
Use google_analytics instead of google_analytics_async

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -36,6 +36,6 @@
     <link href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
     {{ if hugo.Environment | eq "production" }}
-        {{ template "_internal/google_analytics_async.html" . }}
+        {{ template "_internal/google_analytics.html" . }}
     {{ end }}
 </head>


### PR DESCRIPTION
Changing `google_analytics_async` to `google_analytics` since it's been deprecated for a while. 

https://github.com/gohugoio/hugo/commit/c32094ace113412abea354b7119d154168097287